### PR TITLE
Upgrade vendored zsv 1.3.0 → 1.4.3 (fast mode)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.4.3] - 2026-06-26
+
+### Changed
+- Upgraded the vendored zsv C library from 1.3.0 to 1.4.3, which introduces
+  zsv "fast mode" and assorted parser improvements and fixes. See the
+  [zsv 1.4.0 release notes](https://github.com/liquidaty/zsv/releases/tag/v1.4.0).
+- Gem version bumped to 1.4.3 to stay in sync with the bundled zsv library.
+
+### CI / Tooling
+- CI now tests against Ruby 3.3, 3.4, and 4.0.
+- Added a tag-driven release workflow that publishes to RubyGems via trusted
+  publishing (OIDC) and creates a GitHub Release (`rake release:tag`).
+
 ## [1.3.0] - 2025-12-08
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-zsv-ruby: SIMD-accelerated CSV parser gem that's 5-6x faster than Ruby's CSV stdlib. Native C extension wrapping zsv 1.3.0 library. Compiles against zsv 1.3.0, version numbers stay in sync.
+zsv-ruby: SIMD-accelerated CSV parser gem that's 5-6x faster than Ruby's CSV stdlib. Native C extension wrapping zsv 1.4.3 library. Compiles against zsv 1.4.3, version numbers stay in sync.
 
 ## Essential Commands
 
@@ -76,11 +76,11 @@ ext/zsv/
 ## Build System
 
 **extconf.rb downloads zsv at compile time**:
-1. Downloads zsv 1.3.0 tarball using Ruby Net::HTTP (no system curl)
+1. Downloads zsv 1.4.3 tarball using Ruby Net::HTTP (no system curl)
 2. Extracts to `ext/zsv/vendor/` (gitignored)
 3. Runs `./configure && make -C src build`
 4. Links against `build/Linux/rel/gcc/lib/libzsv.a`
-5. Flags: `-O3` for performance, `-I vendor/zsv-1.3.0/include`
+5. Flags: `-O3` for performance, `-I vendor/zsv-1.4.3/include`
 
 ## Testing Strategy
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Or install directly:
 gem install zsv
 ```
 
-The gem will automatically download and compile zsv 1.3.0 during installation.
+The gem will automatically download and compile zsv 1.4.3 during installation.
 
 ## 🚀 Usage
 
@@ -304,9 +304,9 @@ The test suite includes:
 
 ## Compatibility
 
-- **Ruby**: 3.3+ required
+- **Ruby**: 3.3+ required (tested on 3.3, 3.4, 4.0)
 - **Platforms**: Linux, macOS (ARM and x86)
-- **ZSV**: Compiles against zsv 1.3.0
+- **ZSV**: Compiles against zsv 1.4.3
 
 ## 🤝 Contributing
 

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -10,7 +10,7 @@ cd zsv-ruby
 # Install dependencies
 bundle install
 
-# Compile the extension (downloads zsv 1.3.0 automatically)
+# Compile the extension (downloads zsv 1.4.3 automatically)
 bundle exec rake compile
 
 # Run tests
@@ -20,7 +20,7 @@ bundle exec rake spec
 ## Build from Scratch
 
 The gem will automatically:
-1. Download zsv 1.3.0 source from GitHub
+1. Download zsv 1.4.3 source from GitHub
 2. Configure and compile zsv library
 3. Build the Ruby extension
 4. Link everything together

--- a/ext/zsv/extconf.rb
+++ b/ext/zsv/extconf.rb
@@ -9,7 +9,7 @@ require 'zlib'
 require 'openssl'
 
 # ZSV version to compile against
-ZSV_VERSION = '1.3.0' # zsv C library version (not gem version)
+ZSV_VERSION = '1.4.3' # zsv C library version (not gem version)
 ZSV_URL = "https://github.com/liquidaty/zsv/archive/refs/tags/v#{ZSV_VERSION}.tar.gz".freeze
 # Use absolute path relative to the original extconf.rb location
 EXTCONF_DIR = File.expand_path(__dir__)

--- a/lib/zsv/version.rb
+++ b/lib/zsv/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ZSV
-  VERSION = '1.3.1'
+  VERSION = '1.4.3'
 end

--- a/spec/zsv_spec.rb
+++ b/spec/zsv_spec.rb
@@ -3,7 +3,7 @@
 RSpec.describe ZSV do
   it 'has a version number' do
     expect(ZSV::VERSION).not_to be nil
-    expect(ZSV::VERSION).to eq('1.3.1')
+    expect(ZSV::VERSION).to eq('1.4.3')
   end
 
   describe '.parse' do


### PR DESCRIPTION
Closes #2.

## Summary
Upgrades the bundled zsv C library from **1.3.0 → 1.4.3** (latest), which adds zsv **"fast mode"** (per upstream, 20%–1000% faster) plus parser fixes. The gem version is synced to **1.4.3**.

## What changed
- `ext/zsv/extconf.rb`: `ZSV_VERSION` 1.3.0 → 1.4.3 (downloaded + built from source at compile time).
- Gem version 1.3.1 → 1.4.3 + version spec updated.
- zsv version references refreshed in `CLAUDE.md`, `README.md`, `docs/QUICKSTART.md`.
- `CHANGELOG.md`: 1.4.3 entry.

## Verification (local, Ruby 3.4.7)
- Clean rebuild against zsv 1.4.3 **compiles cleanly** — C API is compatible, no source changes needed.
- **28/28 specs pass**, RuboCop 0 offenses.
- Benchmarks still **5.5–7.1× faster** than Ruby's CSV stdlib.

## Note on fast mode
The upgrade pulls in the fast-mode-capable library with no regression. If upstream gates additional speedups behind an explicit zsv option, exposing that can be a small follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)